### PR TITLE
Fix compatibility with tasty-hspec 1.1.7

### DIFF
--- a/tasty-discover.cabal
+++ b/tasty-discover.cabal
@@ -39,6 +39,7 @@ common directory                  { build-depends: directory                  >=
 common filepath                   { build-depends: filepath                   >= 1.3      && < 2.0      }
 common Glob                       { build-depends: Glob                       >= 0.8      && < 1.0      }
 common hedgehog                   { build-depends: hedgehog                   >= 1.0      && < 2.0      }
+common hspec                      { build-depends: hspec                      >= 2.7      && < 2.9      }
 common tasty                      { build-depends: tasty                      >= 1.3      && < 2.0      }
 common tasty-discover             { build-depends: tasty-discover             >= 4.0      && < 5.0      }
 common tasty-hedgehog             { build-depends: tasty-hedgehog             >= 1.0      && < 2.0      }
@@ -82,6 +83,7 @@ test-suite tasty-discover-test
                       , directory
                       , filepath
                       , hedgehog
+                      , hspec
                       , tasty
                       , tasty-hedgehog
                       , tasty-hspec

--- a/test/ConfigTest.hs
+++ b/test/ConfigTest.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TupleSections #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -11,6 +12,10 @@ import Test.Tasty.Generator  (Test (..), mkTest)
 import Test.Tasty.Hspec
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
+
+#if MIN_VERSION_tasty_hspec(1,1,7)
+import Test.Hspec
+#endif
 
 import qualified Data.Map.Strict as M
 

--- a/test/DiscoverTest.hs
+++ b/test/DiscoverTest.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module DiscoverTest where
@@ -7,6 +8,10 @@ import Test.Tasty
 import Test.Tasty.Hspec
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
+
+#if MIN_VERSION_tasty_hspec(1,1,7)
+import Test.Hspec
+#endif
 
 import qualified Hedgehog       as H
 import qualified Hedgehog.Gen   as G


### PR DESCRIPTION
tasty-hspec no longer re-exports Test.Hspec since 1.1.7. Let's import
it ourselves.