### PR TITLE
Add --search-dir DIR option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog] and this project adheres to
 [Keep a Changelog]: http://keepachangelog.com/
 [Semantic Versioning]: http://semver.org/
 
+- Added `--search-dir DIR` option
+
 # 4.2.1 [2018-06-06]
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ Example: `{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --debug #-}`
 Example: `{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --modules="*CustomTest.hs" #-}`
 
   - **--modules**: Which test modules to discover (with glob pattern).
+  - **--search-dir**: Where to look for tests. This is a directory relative
+    to the location of the source file. By default, this is the directory
+    of the source file."
   - **--ignores**: Which test modules to ignore (with glob pattern).
   - **--generated-module**: The name of the generated test module.
   - **--ingredient**: Tasty ingredients to add to your test runner.

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -6,6 +6,7 @@ import Control.Monad       (when)
 import Data.Maybe          (fromMaybe)
 import System.Environment  (getArgs, getProgName)
 import System.Exit         (exitFailure)
+import System.FilePath     (takeDirectory)
 import System.IO           (hPutStrLn, stderr)
 import Test.Tasty.Config   (Config (..), parseConfig)
 import Test.Tasty.Discover (findTests, generateTestDriver)
@@ -17,12 +18,12 @@ main = do
   name <- getProgName
   case args of
     src:_:dst:opts ->
-      case parseConfig name opts of
+      case parseConfig (takeDirectory src) name opts of
         Left err -> do
           hPutStrLn stderr err
           exitFailure
         Right config -> do
-          tests <- findTests src config
+          tests <- findTests config
           let ingredients = tastyIngredients config
               moduleName  = fromMaybe "Main" (generatedModuleName config)
               output      = generateTestDriver config moduleName ingredients src tests

--- a/library/Test/Tasty/Discover.hs
+++ b/library/Test/Tasty/Discover.hs
@@ -14,7 +14,7 @@ module Test.Tasty.Discover
 
 import Data.List            (dropWhileEnd, intercalate, isPrefixOf, nub, stripPrefix)
 import Data.Maybe           (fromMaybe)
-import System.FilePath      (pathSeparator, takeDirectory)
+import System.FilePath      (pathSeparator)
 import System.FilePath.Glob (compile, globDir1, match)
 import System.IO            (IOMode (ReadMode), openFile)
 import Test.Tasty.Config    (Config (..), GlobPattern)
@@ -74,9 +74,9 @@ ignoreByModuleGlob filePaths (Just ignoreGlob) = filter (not . match pattern) fi
   where pattern = compile ("**/" ++ ignoreGlob)
 
 -- | Discover the tests modules.
-findTests :: FilePath -> Config -> IO [Test]
-findTests src config = do
-  let directory = takeDirectory src
+findTests :: Config -> IO [Test]
+findTests config = do
+  let directory = searchDir config
   allModules <- filesByModuleGlob directory (modules config)
   let filtered = ignoreByModuleGlob allModules (ignores config)
   concat <$> traverse (extract directory) filtered

--- a/test/ConfigTest.hs
+++ b/test/ConfigTest.hs
@@ -25,41 +25,42 @@ spec_modules = describe "Test discovery" $ do
     let expectedTests = [ mkTest "PropTest.hs" "prop_additionAssociative"
                         , mkTest "SubSubMod/PropTest.hs" "prop_additionCommutative"
                         ]
-        config        = defaultConfig { modules = Just "*Test.hs" }
-    discoveredTests <- findTests "test/SubMod/" config
+        config        = (defaultConfig "test/SubMod") { modules = Just "*Test.hs" }
+    discoveredTests <- findTests config
     sort discoveredTests `shouldBe` sort expectedTests
 
 spec_ignores :: Spec
 spec_ignores = describe "Module ignore configuration" $ do
   it "Ignores tests in modules with the specified suffix" $ do
-    let ignoreModuleConfig = defaultConfig { ignores = Just "*.hs" }
-    discoveredTests <- findTests "test/SubMod/" ignoreModuleConfig
+    let ignoreModuleConfig = (defaultConfig "test/SubMod") { ignores = Just "*.hs" }
+    discoveredTests <- findTests ignoreModuleConfig
     discoveredTests `shouldBe` []
 
 spec_badModuleGlob :: Spec
 spec_badModuleGlob = describe "Module suffix configuration" $ do
   it "Filters discovered tests by specified suffix" $ do
-    let badGlobConfig = defaultConfig { modules = Just "DoesntExist*.hs" }
-    discoveredTests <- findTests "test/SubMod/" badGlobConfig
+    let badGlobConfig = (defaultConfig "test/SubMod") { modules = Just "DoesntExist*.hs" }
+    discoveredTests <- findTests badGlobConfig
     discoveredTests `shouldBe` []
 
 spec_customModuleName :: Spec
 spec_customModuleName = describe "Module name configuration" $ do
   it "Creates a generated main function with the specified name" $ do
-    let generatedModule = generateTestDriver defaultConfig "FunkyModuleName" [] "test/" []
+    let generatedModule = generateTestDriver (defaultConfig "test/") "FunkyModuleName" [] "test/" []
     "FunkyModuleName" `shouldSatisfy` (`isInfixOf` generatedModule)
 
 unit_noTreeDisplayDefault :: IO ()
 unit_noTreeDisplayDefault = do
-  tests <- findTests "test/SubMod/" defaultConfig
+  let config = defaultConfig "test/SubMod"
+  tests <- findTests config
   let testNumVars = map (('t' :) . show) [(0::Int)..]
-      trees = showTests defaultConfig tests testNumVars
+      trees = showTests config tests testNumVars
   length trees @?= 4
 
 unit_treeDisplay :: IO ()
 unit_treeDisplay = do
-  let config = defaultConfig { treeDisplay = True }
-  tests <- findTests "test/SubMod/" config
+  let config = (defaultConfig "test/SubMod") { treeDisplay = True }
+  tests <- findTests config
   let testNumVars = map (('t' :) . show) [(0::Int)..]
       trees = showTests config tests testNumVars
   length trees @?= 3


### PR DESCRIPTION
This is helpful to deal with situations in which the tests don't reside in the same directory as the generated source file.

We can say
```Haskell
-- This is tests/Main.hs
{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --search-dir=../testlib #-}
```
and collect the tests from a library, for instance.

Another way to achieve this would be to place the generated  file in the library instead, but further constraints prevent this in my use case, which is combining `tasty-discover` with [gazelle_haskell_modules](https://github.com/tweag/gazelle_haskell_modules#preprocessor-support).