### PR TITLE
Make existing library modules internal

### DIFF
--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -2,14 +2,14 @@
 
 module Main where
 
-import Control.Monad       (when)
-import Data.Maybe          (fromMaybe)
-import System.Environment  (getArgs, getProgName)
-import System.Exit         (exitFailure)
-import System.FilePath     (takeDirectory)
-import System.IO           (IOMode(ReadMode), hGetContents, hPutStrLn, withFile, stderr)
-import Test.Tasty.Config   (Config (..), parseConfig)
-import Test.Tasty.Discover (findTests, generateTestDriver)
+import Control.Monad                       (when)
+import Data.Maybe                          (fromMaybe)
+import System.Environment                  (getArgs, getProgName)
+import System.Exit                         (exitFailure)
+import System.FilePath                     (takeDirectory)
+import System.IO                           (IOMode(ReadMode), hGetContents, hPutStrLn, withFile, stderr)
+import Test.Tasty.Discover.Internal.Config (Config (..), parseConfig)
+import Test.Tasty.Discover.Internal.Driver (findTests, generateTestDriver)
 
 -- | Main function.
 main :: IO ()

--- a/library/Test/Tasty/Discover/Internal/Config.hs
+++ b/library/Test/Tasty/Discover/Internal/Config.hs
@@ -3,7 +3,7 @@
 -- Anything that can be passed as an argument to the test driver
 -- definition exists as a field in the 'Config' type.
 
-module Test.Tasty.Config
+module Test.Tasty.Discover.Internal.Config
   ( -- * Configuration Options
     Config (..)
   , GlobPattern

--- a/library/Test/Tasty/Discover/Internal/Driver.hs
+++ b/library/Test/Tasty/Discover/Internal/Driver.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 
 -- | Automatic test discovery and runner for the tasty framework.
-module Test.Tasty.Discover
+module Test.Tasty.Discover.Internal.Driver
   ( -- * Main Test Generator
     generateTestDriver
 
@@ -12,13 +12,13 @@ module Test.Tasty.Discover
   , showTests
   ) where
 
-import Data.List            (dropWhileEnd, intercalate, isPrefixOf, nub, sort, stripPrefix)
-import Data.Maybe           (fromMaybe)
-import System.FilePath      (pathSeparator)
-import System.FilePath.Glob (compile, globDir1, match)
-import System.IO            (IOMode (ReadMode), withFile)
-import Test.Tasty.Config    (Config (..), GlobPattern)
-import Test.Tasty.Generator (Generator (..), Test (..), generators, getGenerators, mkTest, showSetup)
+import Data.List                              (dropWhileEnd, intercalate, isPrefixOf, nub, sort, stripPrefix)
+import Data.Maybe                             (fromMaybe)
+import System.FilePath                        (pathSeparator)
+import System.FilePath.Glob                   (compile, globDir1, match)
+import System.IO                              (IOMode (ReadMode), withFile)
+import Test.Tasty.Discover.Internal.Config    (Config (..), GlobPattern)
+import Test.Tasty.Discover.Internal.Generator (Generator (..), Test (..), generators, getGenerators, mkTest, showSetup)
 
 import qualified Data.Map.Strict as M
 

--- a/library/Test/Tasty/Discover/Internal/Generator.hs
+++ b/library/Test/Tasty/Discover/Internal/Generator.hs
@@ -5,7 +5,7 @@
 -- necessary boilerplate for the generated main function that will
 -- run all the tests.
 
-module Test.Tasty.Generator
+module Test.Tasty.Discover.Internal.Generator
   ( -- * Types
     Generator (..)
   , Test (..)

--- a/tasty-discover.cabal
+++ b/tasty-discover.cabal
@@ -51,9 +51,9 @@ common tasty-quickcheck           { build-depends: tasty-quickcheck           >=
 common tasty-smallcheck           { build-depends: tasty-smallcheck           >= 0.8      && < 1.0      }
 
 library
-  exposed-modules:      Test.Tasty.Config
-                        Test.Tasty.Discover
-                        Test.Tasty.Generator
+  exposed-modules:      Test.Tasty.Discover.Internal.Config
+                        Test.Tasty.Discover.Internal.Driver
+                        Test.Tasty.Discover.Internal.Generator
   other-modules:        Paths_tasty_discover
   autogen-modules:      Paths_tasty_discover
   hs-source-dirs:       library

--- a/test/ConfigTest.hs
+++ b/test/ConfigTest.hs
@@ -5,10 +5,10 @@
 
 module ConfigTest where
 
-import Data.List             (isInfixOf, sort)
-import Test.Tasty.Config
-import Test.Tasty.Discover   (ModuleTree (..), findTests, generateTestDriver, mkModuleTree, showTests)
-import Test.Tasty.Generator  (Test (..), mkTest)
+import Data.List                              (isInfixOf, sort)
+import Test.Tasty.Discover.Internal.Config
+import Test.Tasty.Discover.Internal.Driver    (ModuleTree (..), findTests, generateTestDriver, mkModuleTree, showTests)
+import Test.Tasty.Discover.Internal.Generator (Test (..), mkTest)
 
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck


### PR DESCRIPTION
These are only meant to be called by driver generated code.

Internal modules can change at any time.