### PR TITLE
Fix tasty-hedgehog `testProperty` deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog] and this project adheres to
 - Deduplicate imports in generated code
 - Rename library directory to src
 - Move existing library modules to Test.Discover.Internal
+- Fix tasty-hedgehog `testProperty` deprecation warning
 
 # 4.2.3 [2022-05-21]
 

--- a/README.md
+++ b/README.md
@@ -245,33 +245,6 @@ This is a known limitation and has been reported. No fix is planned unless you h
 
 Please see [#145](https://git.coop/lwm/tasty-discover/issues/145) for more information.
 
-## Deprecation warnings
-
-If you see the `testProperty` deprecation warnings like the following:
-
-```
-test/Driver.hs:77:17: warning: [-Wdeprecations]
-    In the use of ‘testProperty’ (imported from Test.Tasty.Hedgehog):
-    Deprecated: "testProperty will cause Hedgehog to provide incorrect instructions for re-checking properties"
-   |
-77 |   t16 <- pure $ H.testProperty "reverse" DiscoverTest.hprop_reverse
-   |                 ^^^^^^^^^^^^^^
-```
-
-There are two ways to fix it:
-
-One is to suppress the warning.  This can be done for example with an adjustment to the
-Driver preprocessing with the `-Wno-deprecations` option:
-
-```
-{-# OPTIONS_GHC -Wno-deprecations -F -pgmF tasty-discover -optF --hide-successes #-}
-```
-
-Taking this option, whilst quick an easy, risks missing important deprecation warnings however.
-
-The recommended option is define a `Tasty` type class instance for hedgehog.  An example can be
-found in `DiscoverTest` module.
-
 # Maintenance
 
 If you're interested in helping maintain this package, please let [@newhoggy] know!

--- a/src/Test/Tasty/Discover/Internal/Generator.hs
+++ b/src/Test/Tasty/Discover/Internal/Generator.hs
@@ -89,9 +89,9 @@ generators =
 hedgehogPropertyGenerator :: Generator
 hedgehogPropertyGenerator = Generator
   { generatorPrefix   = "hprop_"
-  , generatorImports  = ["import qualified Test.Tasty.Hedgehog as H"]
+  , generatorImports  = ["import qualified Test.Tasty.Hedgehog as H", "import Data.String (fromString)"]
   , generatorClass    = ""
-  , generatorSetup    = \t -> "pure $ H.testProperty \"" ++ name t ++ "\" " ++ qualifyFunction t
+  , generatorSetup    = \t -> "pure $ H.testPropertyNamed \"" ++ name t ++ "\" (fromString \"" ++ qualifyFunction t ++ "\") " ++ qualifyFunction t
   }
 
 -- | Quickcheck group generator prefix.

--- a/tasty-discover.cabal
+++ b/tasty-discover.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:                   tasty-discover
-version:                4.2.4
+version:                5.0.0
 synopsis:               Test discovery for the tasty framework.
 description:            Automatic test discovery and runner for the tasty framework.
                       
@@ -46,7 +46,7 @@ common hspec-core                 { build-depends: hspec-core                 >=
 common tasty                      { build-depends: tasty                      >= 1.3      && < 2.0      }
 common tasty-discover             { build-depends: tasty-discover             >= 4.0      && < 5.0      }
 common tasty-golden               { build-depends: tasty-golden               >= 2.0      && < 3.0      }
-common tasty-hedgehog             { build-depends: tasty-hedgehog             >= 1.1      && < 2.0      }
+common tasty-hedgehog             { build-depends: tasty-hedgehog             >= 1.2      && < 2.0      }
 common tasty-hspec                { build-depends: tasty-hspec                >= 1.1      && < 1.3      }
 common tasty-hunit                { build-depends: tasty-hunit                >= 0.10     && < 0.11     }
 common tasty-quickcheck           { build-depends: tasty-quickcheck           >= 0.10     && < 0.11     }

--- a/test/DiscoverTest.hs
+++ b/test/DiscoverTest.hs
@@ -69,7 +69,7 @@ test_generateTrees :: IO [TestTree]
 test_generateTrees = pure (map (\s -> testCase s $ pure ()) ["First input", "Second input"])
 
 ------------------------------------------------------------------------------------------------
--- How to add custom support for hedgehog to avoid deprecation warning from tasty-hedgehog
+-- How to simultaneously support tasty-hedgehog <1.2 and ^>1.2 using a custom test
 
 newtype Property = Property
   { unProperty :: H.Property
@@ -93,7 +93,7 @@ tasty_reverse = property $ do
   reverse (reverse xs) H.=== xs
 
 ------------------------------------------------------------------------------------------------
--- How to use tasty-hedgehog up to version 1.1
+-- How to use the latest version of tasty-hedgehog
 
 {- HLINT ignore "Avoid reverse" -}
 hprop_reverse :: H.Property

--- a/test/Driver.hs
+++ b/test/Driver.hs
@@ -4,6 +4,7 @@
 
 module Main (main, ingredients, tests) where
 
+import Data.String (fromString)
 import Prelude
 import qualified ConfigTest
 import qualified DiscoverTest
@@ -72,7 +73,7 @@ tests = do
 
   t15 <- TD.tasty (TD.description "reverse" <> TD.name "DiscoverTest.tasty_reverse") DiscoverTest.tasty_reverse
 
-  t16 <- pure $ H.testProperty "reverse" DiscoverTest.hprop_reverse
+  t16 <- pure $ H.testPropertyNamed "reverse" (fromString "DiscoverTest.hprop_reverse") DiscoverTest.hprop_reverse
 
   t17 <- pure $ QC.testProperty "additionCommutative" SubMod.FooBaz.prop_additionCommutative
 


### PR DESCRIPTION
Compiling `hprop_` tests would cause the following warning:

```
Deprecated: "testProperty will cause Hedgehog to provide incorrect instructions for re-checking properties"
```

The recommended solution is to use `testPropertyNamed` instead.

Closes #20