### PR TITLE
Allow for adding wrappers of the test tree

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -26,8 +26,9 @@ main = do
           tests <- findTests config
           let ingredients = tastyIngredients config
               moduleName  = fromMaybe "Main" (generatedModuleName config)
+              wrappers   = testWrappers config
           header <- readHeader src
-          let output = generateTestDriver config moduleName ingredients src tests
+          let output = generateTestDriver config moduleName ingredients wrappers src tests
           when (debug config) $ hPutStrLn stderr output
           when (inPlace config) $ writeFile src $ unlines $ header ++ [marker, output]
           writeFile dst $

--- a/src/Test/Tasty/Discover/Internal/Config.hs
+++ b/src/Test/Tasty/Discover/Internal/Config.hs
@@ -34,6 +34,7 @@ data Config = Config
   , generatedModuleName :: Maybe String      -- ^ Name of the generated main module.
   , ignores             :: Maybe GlobPattern -- ^ Glob pattern for ignoring modules during test discovery.
   , ignoredModules      :: [FilePath]        -- ^ <<<DEPRECATED>>>: Ignored modules by full name.
+  , testWrappers        :: [String]          -- ^ Wrapper functions of the test tree.
   , tastyIngredients    :: [Ingredient]      -- ^ Tasty ingredients to use.
   , tastyOptions        :: [String]          -- ^ Options passed to tasty
   , inPlace             :: Bool              -- ^ Whether the source file should be modified in-place.
@@ -44,7 +45,7 @@ data Config = Config
 
 -- | The default configuration
 defaultConfig :: FilePath -> Config
-defaultConfig theSearchDir = Config Nothing Nothing theSearchDir Nothing Nothing [] [] [] False False False False
+defaultConfig theSearchDir = Config Nothing Nothing theSearchDir Nothing Nothing [] [] [] [] False False False False
 
 -- | Deprecation message for old `--[no-]module-suffix` option.
 moduleSuffixDeprecationMessage :: String
@@ -101,6 +102,9 @@ options srcDir =
   , Option [] ["ignore-module"]
       (ReqArg (\s c -> c {ignoredModules = s : ignoredModules c}) "FILE")
       "<<<DEPRECATED>>>: Ignore a test module"
+  , Option [] ["wrapper"]
+      (ReqArg (\s c -> c {testWrappers = s : testWrappers c}) "WRAPPER")
+      "Qualified test wrapper function name"
   , Option [] ["ingredient"]
       (ReqArg (\s c -> c {tastyIngredients = s : tastyIngredients c}) "INGREDIENT")
       "Qualified tasty ingredient name"


### PR DESCRIPTION
Hi,
I've got a proposed addition to allow for adding functions which modify the test tree before being run. I'm working on a [snapshot testing library][snapshots] and as I understand things, I want to be able to rewrite each source file that needs updating in one pass after all the tests have run. I have an issue open on `tasty` itself to extend ingredients to allow for modifying the test tree [here](https://github.com/UnkindPartition/tasty/issues/453), but another way for me to do what I need would be to just add this extra extension point to `tasty-discover`.

I've set this as a draft PR, if it's a sane approach I can add tests and update the README, etc., if not let me know.

[snapshots]: https://tigerbeetle.com/blog/2024-05-14-snapshot-testing-for-the-masses/