### PR TITLE
Fix backup file import generation bug and add regression test

### DIFF
--- a/src/Test/Tasty/Discover/Internal/Driver.hs
+++ b/src/Test/Tasty/Discover/Internal/Driver.hs
@@ -80,7 +80,7 @@ generateTestDriver config modname is src tests =
 -- | Match files by specified glob pattern.
 filesByModuleGlob :: FilePath -> Maybe GlobPattern -> IO [String]
 filesByModuleGlob directory globPattern = globDir1 pattern directory
-  where pattern = compile ("**/" ++ fromMaybe "*.hs*" globPattern)
+  where pattern = compile ("**/" ++ fromMaybe "*.hs" globPattern)
 
 -- | Filter and remove files by specified glob pattern.
 ignoreByModuleGlob :: [FilePath] -> Maybe GlobPattern -> [FilePath]

--- a/tasty-discover.cabal
+++ b/tasty-discover.cabal
@@ -121,6 +121,7 @@ test-suite tasty-discover-test
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N
   other-modules:        ConfigTest
                         DiscoverTest
+                        BackupFiles.ValidTest
                         SubMod.FooBaz
                         SubMod.PropTest
                         SubMod.SubSubMod.PropTest

--- a/test/BackupFiles/ValidTest.hs
+++ b/test/BackupFiles/ValidTest.hs
@@ -1,0 +1,8 @@
+module BackupFiles.ValidTest where
+
+-- This module is part of the regression test for spec_backupFilesIgnored
+-- in ConfigTest.hs. The accompanying .hs.orig and .hs.bak files test
+-- that tasty-discover only processes .hs files and ignores backup files.
+
+prop_validTest :: Bool -> Bool
+prop_validTest _ = True

--- a/test/BackupFiles/ValidTest.hs.bak
+++ b/test/BackupFiles/ValidTest.hs.bak
@@ -1,0 +1,8 @@
+module BackupFiles.ValidTest where
+
+-- DO NOT DELETE: This backup file is part of the regression test
+-- for spec_backupFilesIgnored in ConfigTest.hs
+-- It tests that tasty-discover ignores .hs.bak files
+-- This is another backup version that should be ignored
+prop_anotherOldTest :: Bool -> Bool
+prop_anotherOldTest _ = False

--- a/test/BackupFiles/ValidTest.hs.orig
+++ b/test/BackupFiles/ValidTest.hs.orig
@@ -1,0 +1,8 @@
+module BackupFiles.ValidTest where
+
+-- DO NOT DELETE: This backup file is part of the regression test
+-- for spec_backupFilesIgnored in ConfigTest.hs
+-- It tests that tasty-discover ignores .hs.orig files
+-- This is a backup version that should be ignored
+prop_oldTest :: Bool -> Bool
+prop_oldTest _ = False

--- a/test/Driver.hs
+++ b/test/Driver.hs
@@ -6,6 +6,7 @@ module Main (main, ingredients, tests) where
 
 import Data.String (fromString)
 import Prelude
+import qualified BackupFiles.ValidTest
 import qualified ConfigTest
 import qualified DiscoverTest
 import qualified SubMod.FooBaz
@@ -42,49 +43,53 @@ instance TestCase ((String -> IO ()) -> IO ()) where testCase n = pure . HU.test
 
 tests :: IO T.TestTree
 tests = do
-  t0 <- HS.testSpec "modules" ConfigTest.spec_modules
+  t0 <- pure $ QC.testProperty "validTest" BackupFiles.ValidTest.prop_validTest
 
-  t1 <- HS.testSpec "ignores" ConfigTest.spec_ignores
+  t1 <- HS.testSpec "modules" ConfigTest.spec_modules
 
-  t2 <- HS.testSpec "badModuleGlob" ConfigTest.spec_badModuleGlob
+  t2 <- HS.testSpec "ignores" ConfigTest.spec_ignores
 
-  t3 <- HS.testSpec "customModuleName" ConfigTest.spec_customModuleName
+  t3 <- HS.testSpec "badModuleGlob" ConfigTest.spec_badModuleGlob
 
-  t4 <- testCase "noTreeDisplayDefault" ConfigTest.unit_noTreeDisplayDefault
+  t4 <- HS.testSpec "backupFilesIgnored" ConfigTest.spec_backupFilesIgnored
 
-  t5 <- testCase "treeDisplay" ConfigTest.unit_treeDisplay
+  t5 <- HS.testSpec "customModuleName" ConfigTest.spec_customModuleName
 
-  t6 <- pure $ QC.testProperty "mkModuleTree" ConfigTest.prop_mkModuleTree
+  t6 <- testCase "noTreeDisplayDefault" ConfigTest.unit_noTreeDisplayDefault
 
-  t7 <- testCase "listCompare" DiscoverTest.unit_listCompare
+  t7 <- testCase "treeDisplay" ConfigTest.unit_treeDisplay
 
-  t8 <- pure $ QC.testProperty "additionCommutative" DiscoverTest.prop_additionCommutative
+  t8 <- pure $ QC.testProperty "mkModuleTree" ConfigTest.prop_mkModuleTree
 
-  t9 <- pure $ SC.testProperty "sortReverse" DiscoverTest.scprop_sortReverse
+  t9 <- testCase "listCompare" DiscoverTest.unit_listCompare
 
-  t10 <- HS.testSpec "prelude" DiscoverTest.spec_prelude
+  t10 <- pure $ QC.testProperty "additionCommutative" DiscoverTest.prop_additionCommutative
 
-  t11 <- testGroup "addition" DiscoverTest.test_addition
+  t11 <- pure $ SC.testProperty "sortReverse" DiscoverTest.scprop_sortReverse
 
-  t12 <- testGroup "multiplication" DiscoverTest.test_multiplication
+  t12 <- HS.testSpec "prelude" DiscoverTest.spec_prelude
 
-  t13 <- testGroup "generateTree" DiscoverTest.test_generateTree
+  t13 <- testGroup "addition" DiscoverTest.test_addition
 
-  t14 <- testGroup "generateTrees" DiscoverTest.test_generateTrees
+  t14 <- testGroup "multiplication" DiscoverTest.test_multiplication
 
-  t15 <- TD.tasty (TD.description "reverse" <> TD.name "DiscoverTest.tasty_reverse") DiscoverTest.tasty_reverse
+  t15 <- testGroup "generateTree" DiscoverTest.test_generateTree
 
-  t16 <- pure $ H.testPropertyNamed "reverse" (fromString "DiscoverTest.hprop_reverse") DiscoverTest.hprop_reverse
+  t16 <- testGroup "generateTrees" DiscoverTest.test_generateTrees
 
-  t17 <- pure $ QC.testProperty "additionCommutative" SubMod.FooBaz.prop_additionCommutative
+  t17 <- TD.tasty (TD.description "reverse" <> TD.name "DiscoverTest.tasty_reverse") DiscoverTest.tasty_reverse
 
-  t18 <- pure $ QC.testProperty "multiplationDistributiveOverAddition" SubMod.FooBaz.prop_multiplationDistributiveOverAddition
+  t18 <- pure $ H.testPropertyNamed "reverse" (fromString "DiscoverTest.hprop_reverse") DiscoverTest.hprop_reverse
 
-  t19 <- pure $ QC.testProperty "additionAssociative" SubMod.PropTest.prop_additionAssociative
+  t19 <- pure $ QC.testProperty "additionCommutative" SubMod.FooBaz.prop_additionCommutative
 
-  t20 <- pure $ QC.testProperty "additionCommutative" SubMod.SubSubMod.PropTest.prop_additionCommutative
+  t20 <- pure $ QC.testProperty "multiplationDistributiveOverAddition" SubMod.FooBaz.prop_multiplationDistributiveOverAddition
 
-  pure $ T.testGroup "test/Driver.hs" [t0,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13,t14,t15,t16,t17,t18,t19,t20]
+  t21 <- pure $ QC.testProperty "additionAssociative" SubMod.PropTest.prop_additionAssociative
+
+  t22 <- pure $ QC.testProperty "additionCommutative" SubMod.SubSubMod.PropTest.prop_additionCommutative
+
+  pure $ T.testGroup "test/Driver.hs" [t0,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13,t14,t15,t16,t17,t18,t19,t20,t21,t22]
 ingredients :: [T.Ingredient]
 ingredients = T.defaultIngredients
 main :: IO ()


### PR DESCRIPTION
- Fixed file discovery pattern from "*.hs*" to "*.hs" in Driver.hs
- Prevents backup files (.hs.orig, .hs.bak) from being processed as test modules
- Added regression test spec_backupFilesIgnored to prevent future regressions
- Created test/BackupFiles/ directory with test data to verify fix
- Updated cabal file to include new test module

Fixes issue where files like "Foo.hs.orig" would generate invalid imports like "import qualified Foo.hs" instead of being ignored.

Before: Files matching "*.hs*" included backup files
After: Only files ending with ".hs" are processed