### PR TITLE
Add reproduction test for symlink crash issue (#38)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/tasty-discover.cabal
+++ b/tasty-discover.cabal
@@ -55,6 +55,9 @@ common tasty-hspec                { build-depends: tasty-hspec                >=
 common tasty-hunit                { build-depends: tasty-hunit                >= 0.10     && < 0.11     }
 common tasty-quickcheck           { build-depends: tasty-quickcheck           >= 0.10     && < 0.11     }
 common tasty-smallcheck           { build-depends: tasty-smallcheck           >= 0.8      && < 1.0      }
+common tasty-expected-failure     { build-depends: tasty-expected-failure     >= 0.12     && < 0.13     }
+common process                    { build-depends: process                    >= 1.6      && < 2.0      }
+common temporary                  { build-depends: temporary                  >= 1.3      && < 1.4      }
 
 common project-config
   default-extensions:   DeriveGeneric
@@ -106,16 +109,21 @@ test-suite tasty-discover-test
   import:               base, project-config
                       , bytestring
                       , containers
+                      , directory
+                      , filepath
                       , hedgehog
                       , hspec
                       , hspec-core
+                      , process
                       , tasty
+                      , tasty-expected-failure
                       , tasty-golden
                       , tasty-hedgehog
                       , tasty-hspec
                       , tasty-hunit
                       , tasty-quickcheck
                       , tasty-smallcheck
+                      , temporary
   type:                 exitcode-stdio-1.0
   main-is:              Driver.hs
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N

--- a/test/Driver.hs
+++ b/test/Driver.hs
@@ -67,39 +67,43 @@ tests = do
 
   t10 <- HS.testSpec "commentHandling" ConfigTest.spec_commentHandling
 
-  t11 <- testCase "listCompare" DiscoverTest.unit_listCompare
+  t11 <- HS.testSpec "symlinksNotFollowed" ConfigTest.spec_symlinksNotFollowed
 
-  t12 <- pure $ QC.testProperty "additionCommutative" DiscoverTest.prop_additionCommutative
+  t12 <- TD.tasty (TD.description "symlinksNotFollowed" <> TD.name "ConfigTest.tasty_symlinksNotFollowed") ConfigTest.tasty_symlinksNotFollowed
 
-  t13 <- pure $ SC.testProperty "sortReverse" DiscoverTest.scprop_sortReverse
+  t13 <- testCase "listCompare" DiscoverTest.unit_listCompare
 
-  t14 <- HS.testSpec "prelude" DiscoverTest.spec_prelude
+  t14 <- pure $ QC.testProperty "additionCommutative" DiscoverTest.prop_additionCommutative
 
-  t15 <- testGroup "addition" DiscoverTest.test_addition
+  t15 <- pure $ SC.testProperty "sortReverse" DiscoverTest.scprop_sortReverse
 
-  t16 <- testGroup "multiplication" DiscoverTest.test_multiplication
+  t16 <- HS.testSpec "prelude" DiscoverTest.spec_prelude
 
-  t17 <- testGroup "generateTree" DiscoverTest.test_generateTree
+  t17 <- testGroup "addition" DiscoverTest.test_addition
 
-  t18 <- testGroup "generateTrees" DiscoverTest.test_generateTrees
+  t18 <- testGroup "multiplication" DiscoverTest.test_multiplication
 
-  t19 <- TD.tasty (TD.description "reverse" <> TD.name "DiscoverTest.tasty_reverse") DiscoverTest.tasty_reverse
+  t19 <- testGroup "generateTree" DiscoverTest.test_generateTree
 
-  t20 <- pure $ H.testPropertyNamed "reverse" (fromString "DiscoverTest.hprop_reverse") DiscoverTest.hprop_reverse
+  t20 <- testGroup "generateTrees" DiscoverTest.test_generateTrees
 
-  t21 <- pure $ QC.testProperty "subTest" ModulesGlob.Sub.OneTest.prop_subTest
+  t21 <- TD.tasty (TD.description "reverse" <> TD.name "DiscoverTest.tasty_reverse") DiscoverTest.tasty_reverse
 
-  t22 <- pure $ QC.testProperty "topLevelTest" ModulesGlob.TwoTest.prop_topLevelTest
+  t22 <- pure $ H.testPropertyNamed "reverse" (fromString "DiscoverTest.hprop_reverse") DiscoverTest.hprop_reverse
 
-  t23 <- pure $ QC.testProperty "additionCommutative" SubMod.FooBaz.prop_additionCommutative
+  t23 <- pure $ QC.testProperty "subTest" ModulesGlob.Sub.OneTest.prop_subTest
 
-  t24 <- pure $ QC.testProperty "multiplationDistributiveOverAddition" SubMod.FooBaz.prop_multiplationDistributiveOverAddition
+  t24 <- pure $ QC.testProperty "topLevelTest" ModulesGlob.TwoTest.prop_topLevelTest
 
-  t25 <- pure $ QC.testProperty "additionAssociative" SubMod.PropTest.prop_additionAssociative
+  t25 <- pure $ QC.testProperty "additionCommutative" SubMod.FooBaz.prop_additionCommutative
 
-  t26 <- pure $ QC.testProperty "additionCommutative" SubMod.SubSubMod.PropTest.prop_additionCommutative
+  t26 <- pure $ QC.testProperty "multiplationDistributiveOverAddition" SubMod.FooBaz.prop_multiplationDistributiveOverAddition
 
-  pure $ T.testGroup "test/Driver.hs" [t0,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13,t14,t15,t16,t17,t18,t19,t20,t21,t22,t23,t24,t25,t26]
+  t27 <- pure $ QC.testProperty "additionAssociative" SubMod.PropTest.prop_additionAssociative
+
+  t28 <- pure $ QC.testProperty "additionCommutative" SubMod.SubSubMod.PropTest.prop_additionCommutative
+
+  pure $ T.testGroup "test/Driver.hs" [t0,t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13,t14,t15,t16,t17,t18,t19,t20,t21,t22,t23,t24,t25,t26,t27,t28]
 ingredients :: [T.Ingredient]
 ingredients = T.defaultIngredients
 main :: IO ()


### PR DESCRIPTION
Create test that reproduces tasty-discover crash when encountering symlinked
directories, marked as expected failure until issue is resolved.

Changes:
* test/ConfigTest.hs: Add symlink reproduction test
  - spec_symlinksNotFollowed: Placeholder Hspec test
  - tasty_symlinksNotFollowed: Tasty test using expectFail
  - Creates temp directory with real test files and symlinked directory
  - Calls tasty-discover subprocess and expects crash with specific error
  - Uses expectFail to mark as expected failure until #38 is fixed

* tasty-discover.cabal: Add test dependencies
  - tasty-expected-failure: For expectFail functionality
  - process, temporary, directory, filepath: For symlink testing

* test/Driver.hs: Auto-generated to include new tests
* cabal.project: Add packages specification
* test-symlink-repro/: Add minimal reproduction test project