### PR TITLE
docs: improve release process documentation with explicit git commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,22 +705,29 @@ This project’s release flow is automated via GitHub Actions and driven by the 
 Release checklist:
 
 1) Prepare notes
-- Update `CHANGELOG.md`: move items from “Unreleased” to a new version section with the current date.
+- Update `CHANGELOG.md`: move items from "Unreleased" to a new version section with the current date.
 
 2) Bump version
 - Edit `tasty-discover.cabal` and set `version:` to the new version (e.g., `5.x.y`).
 
-3) Merge to main
-- Open a PR with the changelog and version bump; once CI passes, merge to `main`.
+3) Commit and tag
+- Commit the changes: `git commit -m "Release X.Y.Z"`
+- Create a git tag: `git tag -a vX.Y.Z -m "Release version X.Y.Z"`
 
-4) CI does the rest (automated)
-- Tags `v<version>` from the cabal file.
-- Builds source distributions (`cabal v2-sdist`).
-- Uploads to Hackage (requires repo secrets `HACKAGE_USER`/`HACKAGE_PASS`).
-- Creates a draft GitHub Release for the tag.
+4) Push to GitHub
+- Push the commit: `git push origin main`
+- Push the tag: `git push origin vX.Y.Z` (or let CI create it automatically)
 
-5) Publish release
-- Edit the draft GitHub Release notes if needed and publish.
+5) CI does the rest (automated)
+- Once pushed to `main`, GitHub Actions detects the version in `tasty-discover.cabal`
+- Tags `v<version>` from the cabal file (if not already tagged)
+- Builds source distributions (`cabal v2-sdist`)
+- Uploads to Hackage (requires repo secrets `HACKAGE_USER`/`HACKAGE_PASS`)
+- Creates a draft GitHub Release for the tag
+
+6) Publish release
+- Go to https://github.com/haskell-works/tasty-discover/releases
+- Edit the draft GitHub Release notes if needed and publish
 
 Notes:
 - The workflow is defined in `.github/workflows/haskell.yml`.


### PR DESCRIPTION
# Pull Request

## Description
This PR improves the release process documentation in the README by adding explicit git commands and clarifying the automation steps. The changes make it easier for maintainers to follow the release workflow by providing clear, actionable commands at each step.

## Type of Change
- [x] Documentation update

## Changes Made
- Added explicit git commit command for creating the release commit
- Added explicit git tag creation command with proper formatting
- Separated the git push commands into distinct steps for commit and tag
- Clarified that CI automation triggers after pushing to main
- Added direct link to GitHub releases page for easier access
- Reorganized steps to show manual actions vs automated CI actions more clearly
- Updated step numbering from 5 to 6 steps to accommodate the new commit/tag step

## Testing
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [x] Manual testing performed

## Additional Notes
The updated documentation now provides a clearer separation between what maintainers need to do manually (steps 1-4, 6) and what GitHub Actions handles automatically (step 5). This should reduce confusion during the release process and ensure all necessary git operations are performed correctly.