### PR TITLE
ci: migrate to tag-triggered release process

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
 
 jobs:
@@ -78,8 +80,6 @@ jobs:
   check:
     needs: build
     runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.tag.outputs.tag }}
 
     steps:
       - uses: actions/checkout@v2
@@ -93,34 +93,10 @@ jobs:
             cabal check
           done
 
-      - name: Tag new version
-        id: tag
-        if: ${{ github.ref == 'refs/heads/main' }}
-        env:
-          server: http://hackage.haskell.org
-          username: ${{ secrets.HACKAGE_USER }}
-          password: ${{ secrets.HACKAGE_PASS }}
-        run: |
-          package_version="$(cat *.cabal | grep '^version:' | cut -d : -f 2 | xargs)"
-
-          echo "Package version is v$package_version"
-
-          git fetch --unshallow origin
-
-          if git tag "v$package_version"; then
-            echo "Tagging with new version "v$package_version""
-
-            if git push origin "v$package_version"; then
-              echo "Tagged with new version "v$package_version""
-
-              echo "::set-output name=tag::v$package_version"
-            fi
-          fi
-
   release:
     needs: [build, check]
     runs-on: ubuntu-latest
-    if: ${{ needs.check.outputs.tag != '' }}
+    if: startsWith(github.ref, 'refs/tags/v')
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
 
@@ -172,10 +148,13 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: Undocumented
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          body: |
+            Release ${{ github.ref_name }}
+
+            See [CHANGELOG.md](https://github.com/haskell-works/tasty-discover/blob/main/CHANGELOG.md) for details.
           draft: true
           prerelease: false

--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ We try to keep [tagged releases] in our release process, if you care about that.
 
 # Releasing
 
-This project’s release flow is automated via GitHub Actions and driven by the version in `tasty-discover.cabal`.
+This project's release flow is automated via GitHub Actions and triggered by pushing version tags.
 
 Release checklist:
 
@@ -710,20 +710,21 @@ Release checklist:
 2) Bump version
 - Edit `tasty-discover.cabal` and set `version:` to the new version (e.g., `5.x.y`).
 
-3) Commit and tag
+3) Commit changes
 - Commit the changes: `git commit -m "Release X.Y.Z"`
-- Create a git tag: `git tag -a vX.Y.Z -m "Release version X.Y.Z"`
-
-4) Push to GitHub
 - Push the commit: `git push origin main`
-- Push the tag: `git push origin vX.Y.Z` (or let CI create it automatically)
+
+4) Create and push tag
+- Create a git tag: `git tag -a vX.Y.Z -m "Release version X.Y.Z"`
+- Push the tag: `git push origin vX.Y.Z`
 
 5) CI does the rest (automated)
-- Once pushed to `main`, GitHub Actions detects the version in `tasty-discover.cabal`
-- Tags `v<version>` from the cabal file (if not already tagged)
-- Builds source distributions (`cabal v2-sdist`)
-- Uploads to Hackage (requires repo secrets `HACKAGE_USER`/`HACKAGE_PASS`)
-- Creates a draft GitHub Release for the tag
+- When the tag is pushed, GitHub Actions automatically:
+  - Runs the full test suite
+  - Validates the cabal project with `cabal check`
+  - Builds source distributions (`cabal v2-sdist`)
+  - Uploads to Hackage (requires repo secrets `HACKAGE_USER`/`HACKAGE_PASS`)
+  - Creates a draft GitHub Release for the tag
 
 6) Publish release
 - Go to https://github.com/haskell-works/tasty-discover/releases
@@ -731,7 +732,8 @@ Release checklist:
 
 Notes:
 - The workflow is defined in `.github/workflows/haskell.yml`.
-- Keep `tested-with` in the cabal file up to date with CI’s GHC matrix.
+- The release workflow only triggers on tags matching `v[0-9]+.[0-9]+.[0-9]+` (e.g., v5.2.0).
+- Keep `tested-with` in the cabal file up to date with CI's GHC matrix.
 
 # Deprecation Policy
 


### PR DESCRIPTION
# Pull Request

## Description
This PR refactors the GitHub Actions release workflow to use git tags as the primary trigger for releases instead of automatically creating tags from the main branch. This change provides maintainers with explicit control over when releases occur while maintaining full automation once a tag is pushed.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made
- Modified GitHub Actions workflow to trigger releases on version tag pushes (`v[0-9]+.[0-9]+.[0-9]+`)
- Removed automatic tag creation logic from the `check` job that previously ran on main branch pushes
- Updated release job to use `github.ref_name` for proper tag reference handling
- Added changelog link to release body for better documentation
- Updated README with new tag-based release instructions
- Clarified the manual tag creation and push process in documentation
- Expanded CI automation details to show the complete release workflow

## Testing
- [x] All existing tests pass
- [ ] New tests added for new functionality
- [x] Manual testing performed

## Additional Notes
The previous workflow automatically created tags whenever changes were pushed to main with a new version in the cabal file. This new approach requires maintainers to explicitly create and push tags to trigger releases, providing better control over release timing. The workflow still maintains full automation for building, testing, and publishing to Hackage once a tag is pushed.

Key workflow changes:
- Release triggers changed from `main` branch push to tag push
- Tag pattern requirement: `v[0-9]+.[0-9]+.[0-9]+`
- Release creation now includes link to CHANGELOG.md
- Documentation updated to reflect the new manual tag process